### PR TITLE
Get results of anchorate, update README.md docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ exports.onRouteChange = () => {
 ```
 
 ### Customize the scrolling behavior
+You can provide your own scrolling behavior by passing in a `scroller` function
+in an options object. It is expected that you return true if the scroll was
+successful.
 ```js
 anchorate({ 
   scroller: function (element) {
@@ -69,6 +72,10 @@ anchorate({
 ```
 
 ### Getting results
+You can provide a completion callback function in the options object to be
+informed when the operation has complete and if there were any errors.
+An error will be returned if the element referred to in the hash was not
+found.
 ```js
 anchorate({ 
   callback: function (error) {

--- a/README.md
+++ b/README.md
@@ -57,6 +57,28 @@ exports.onRouteChange = () => {
 }
 ```
 
+### Customize the scrolling behavior
+```js
+anchorate({ 
+  scroller: function (element) {
+    if (!element) return false
+    element.scrollIntoView({ behavior: 'smooth' })
+    return true
+  }
+})
+```
+
+### Getting results
+```js
+anchorate({ 
+  callback: function (success) {
+    if (!success) {
+      // Do something
+    }
+  }
+})
+```
+
 [react router]: https://github.com/reactjs/react-router
 [history]: https://github.com/ReactJSTraining/history
 [gatsby]: https://github.com/gatsbyjs/gatsby

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ anchorate({
 ### Getting results
 ```js
 anchorate({ 
-  callback: function (success) {
-    if (!success) {
+  callback: function (error) {
+    if (error) {
       // Do something
     }
   }

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ exports.hash = function hash (h, options) {
   options = options || {}
   var cb = options.callback || function () {}
   // There's no hash to scroll to, so "success", we did it.
-  if (!h) return void cb(false)
+  if (!h) return void cb()
   var scroller = options.scroller || exports.scroller
   // Push onto callback queue so it runs after the DOM is updated,
   // this is required when navigating from a different page so that
@@ -17,8 +17,9 @@ exports.hash = function hash (h, options) {
   setTimeout(function () {
     var els = exports.elements(h)
     if (!els) return void cb(true)
-    if (scroller(els.id)) return void cb(false)
-    cb(!scroller(els.name))
+    if (scroller(els.id)) return void cb()
+    if (scroller(els.id)) return void cb()
+    cb(true)
   }, 0)
 }
 

--- a/index.js
+++ b/index.js
@@ -17,8 +17,7 @@ exports.hash = function hash (h, options) {
   setTimeout(function () {
     var els = exports.elements(h)
     if (!els) return void cb(true)
-    if (scroller(els.id)) return void cb()
-    if (scroller(els.id)) return void cb()
+    if (scroller(els.id) || scroller(els.name)) return void cb()
     cb(true)
   }, 0)
 }

--- a/index.js
+++ b/index.js
@@ -6,17 +6,19 @@
 var CSSescape = require('css.escape')
 
 exports.hash = function hash (h, options) {
-  if (!h) return
   options = options || {}
+  var cb = options.callback || function () {}
+  // There's no hash to scroll to, so "success", we did it.
+  if (!h) return void cb(true)
   var scroller = options.scroller || exports.scroller
   // Push onto callback queue so it runs after the DOM is updated,
   // this is required when navigating from a different page so that
   // the element is rendered on the page before trying to getElementById.
   setTimeout(function () {
     var els = exports.elements(h)
-    if (!els) return
-    if (scroller(els.id)) return
-    scroller(els.name)
+    if (!els) return void cb(false)
+    if (scroller(els.id)) return void cb(true)
+    cb(scroller(els.name))
   }, 0)
 }
 

--- a/index.js
+++ b/index.js
@@ -9,16 +9,16 @@ exports.hash = function hash (h, options) {
   options = options || {}
   var cb = options.callback || function () {}
   // There's no hash to scroll to, so "success", we did it.
-  if (!h) return void cb(true)
+  if (!h) return void cb(false)
   var scroller = options.scroller || exports.scroller
   // Push onto callback queue so it runs after the DOM is updated,
   // this is required when navigating from a different page so that
   // the element is rendered on the page before trying to getElementById.
   setTimeout(function () {
     var els = exports.elements(h)
-    if (!els) return void cb(false)
-    if (scroller(els.id)) return void cb(true)
-    cb(scroller(els.name))
+    if (!els) return void cb(true)
+    if (scroller(els.id)) return void cb(false)
+    cb(!scroller(els.name))
   }, 0)
 }
 


### PR DESCRIPTION
With the advent of `react@16`'s asynchronous rendering, it is possible that the `setTimeout(fn, 0)` is not sufficient.  This will allow the caller to react to that and to know when anchorate has completed it's logic and whether or not it was able to scroll that element into view.

For my project, this resulted in needing to sometimes call into `anchorate` again after a longer timeout, especially on initial page load.

I've also updated the README.md documentation to reflect this logic (and the existing scroller-replacement logic).