### PR TITLE
Replace `onRouteChange` with `onRouteUpdate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ In `gastby-browser.js`:
 ```js
 import { anchorate } from 'anchorate'
 
-exports.onRouteChange = () => {
+exports.onRouteUpdate = () => {
   anchorate()
 }
 ```


### PR DESCRIPTION
`onRouteChange` was deprecated (and possibly even removed) in favor of `onRouteUpdate`
https://github.com/gatsbyjs/gatsby/pull/321